### PR TITLE
Fix typo

### DIFF
--- a/mythbusting/ip-dns-diagram-handling.md
+++ b/mythbusting/ip-dns-diagram-handling.md
@@ -9,7 +9,7 @@ The MOJ does **not** consider it's IP address, DNS or architectural information 
 
 In some contexts, this information may be considered sensitive (usually when combined with other information), for example, "Server X on IP address x.x.x.x has not been security patched for 5 years and there are known vulnerabilities which are unmitigated and thus could actively be exploited in this moment."
 
-IP addresses of connecting clients (for example, the IP address of the computer of a general member of the public accessing a public MOJ digital service) *may* Personal Data.
+IP addresses of connecting clients (for example, the IP address of the computer of a general member of the public accessing a public MOJ digital service) *may* be Personal Data.
 
 ### RFC1918 addresses
 


### PR DESCRIPTION
Missing 'be' in this. Reported by our friends at the NCSC!