### PR TITLE
Fix bullet formatting

### DIFF
--- a/principles/security-log-collection.md
+++ b/principles/security-log-collection.md
@@ -32,40 +32,40 @@ To enable ease of referencing, but not to imply priority order, each item is ass
 
 ### 1. Authentication events
 
-* a. login successes and failures
-* b. multi-factor authentication success and failures
-* c. logouts
-* d. session creation
-* e. session timeout/expiry
-* f. session close
+* a: login successes and failures
+* b: multi-factor authentication success and failures
+* c: logouts
+* d: session creation
+* e: session timeout/expiry
+* f: session close
 
 ### 2. Authorisation events
 
-* a. group/role creation, modification or deletion
-* b. group/role membership changes (addition or subtraction)
-* c. group/role elevation (for example, if a user is able to temporarily assume a higher privilege to conduct a finite amount of work)
+* a: group/role creation, modification or deletion
+* b: group/role membership changes (addition or subtraction)
+* c: group/role elevation (for example, if a user is able to temporarily assume a higher privilege to conduct a finite amount of work)
 
 ### 3. Infrastructure events
 
 Infrastructure is defined as underlying resources, whether a logical switch, server or through to a containerised compute resource in the cloud, upon which end-user or application logic is overlaid.
 
-* a. power/service on / off
-* b. creation/registration and deletion/de-registration, including suspension/hibernation if applicable
-* c. software update events/status
-* e. IP address allocation/deallocation
-* f. Firewall/routing rule creation, modification or deletion
-* g. Network change events (for example addition or removal of virtual networks or interfaces)
+* a: power/service on / off
+* b: creation/registration and deletion/de-registration, including suspension/hibernation if applicable
+* c: software update events/status
+* e: IP address allocation/deallocation
+* f: Firewall/routing rule creation, modification or deletion
+* g: Network change events (for example addition or removal of virtual networks or interfaces)
 
 ### 4. Domain name service queries
 
-* a. successful and unsuccessful queries
-* b. recursive lookup status
-* c. infrastructure node / end-user device registration / de-registration (if applicable)
+* a: successful and unsuccessful queries
+* b: recursive lookup status
+* c: infrastructure node / end-user device registration / de-registration (if applicable)
 
 ### 5. Network traffic events
 
-* a. successful and unsuccessful inbound service daemon connections
-* b. unsuccessful outbound connections where the network traffic is *not* associated to an inbound request
+* a: successful and unsuccessful inbound service daemon connections
+* b: unsuccessful outbound connections where the network traffic is *not* associated to an inbound request
 
 ### 6. Contextual security related events
 
@@ -75,6 +75,6 @@ For example, operating system patch state information from end-point protection 
 
 ### 7. Log transmission to the MOJ Cyber Security Logging Platform
 
-* a. All log data must be sent to the MOJ Cyber Security owned log platform unless all principles have already been met through the deployment of a holistic locally deployed and monitored Security Information and Event Management (SIEM) solution.
+* a: All log data must be sent to the MOJ Cyber Security owned log platform unless all principles have already been met through the deployment of a holistic locally deployed and monitored Security Information and Event Management (SIEM) solution.
 
 Where 7(a) above is true, the MOJ Cyber Security team will advise in context what information must be sent from the in-place SIEM to the MOJ Cyber Security Logging Platform.

--- a/standards/cots-applications.md
+++ b/standards/cots-applications.md
@@ -37,10 +37,10 @@ These event types must be logged and forward:
 * h. group creation
 * i. privilege modification for users (for example, role delegation through AWS IAM)
 * k. multi-factor authentication state, such as:
-⋅⋅1. enabled
-⋅⋅2. disabled
-⋅⋅3. reset/rotation
-⋅⋅4. recovery method used
+    * 1: enabled
+    * 2: disabled
+    * 3: reset/rotation
+    * 4: recovery method used
 
 ### 2. Authenticated user activity events
 Log Collection Principle(s): 6
@@ -70,10 +70,10 @@ Log Collection Principle(s): 6
 
 Where unauthenticated users interact with applications (for example, a MOJ G-Suite document available on the general Internet through relaxed access controls), associated audit information must be created.
 
-* a. end-client identifier(s) 
+* a. end-client identifier(s)
 * b. query metadata
-⋅⋅1. destination identifier (such as target hostname, TCP/UDP port and/or full URI)
-⋅⋅2. query type (for example, HTTP GET or HTTP POST)
-⋅⋅3. query size
+    * 1: destination identifier (such as target hostname, TCP/UDP port and/or full URI)
+    * 2: query type (for example, HTTP GET or HTTP POST)
+    * 3: query size
 * c. response size
 * d. response time

--- a/standards/cots-applications.md
+++ b/standards/cots-applications.md
@@ -27,16 +27,16 @@ User directories within application environments can be rich and diverse, such t
 * Local user stores within operating systems leveraged by tenant applications
 
 These event types must be logged and forward:
-* a. account creation
-* b. account lockout
-* c. account reinstatement
-* d. account authentication failures
-* e. account authentication successes after 1 or more failures
-* f. account password changes
-* g. group membership addition / deletion (in particular, any group that gives admin access)
-* h. group creation
-* i. privilege modification for users (for example, role delegation through AWS IAM)
-* k. multi-factor authentication state, such as:
+* a: account creation
+* b: account lockout
+* c: account reinstatement
+* d: account authentication failures
+* e: account authentication successes after 1 or more failures
+* f: account password changes
+* g: group membership addition / deletion (in particular, any group that gives admin access)
+* h: group creation
+* i: privilege modification for users (for example, role delegation through AWS IAM)
+* k: multi-factor authentication state, such as:
     * 1: enabled
     * 2: disabled
     * 3: reset/rotation
@@ -47,10 +47,10 @@ Log Collection Principle(s): 6
 
 Applications should create viable user activity audit information for authenticated users to reasonably identify which authenticated user took which action.
 
-* a. user/group identifier(s)
-* b. action/query
-* c. response size
-* d. response time
+* a: user/group identifier(s)
+* b: action/query
+* c: response size
+* d: response time
 
 ## Enhanced Maturity Tier
 
@@ -59,21 +59,21 @@ Log Collection Principle(s): 6
 
 Temporary data stores (such as intermediate queues) and permanent data store (such as databases) are key data locations and all interactions should be highly auditable.
 
-* a. data store identifier(s)
-* b. credential identifier(s)
-* c. query
-* d. query response size
-* e. query response time
+* a: data store identifier(s)
+* b: credential identifier(s)
+* c: query
+* d: query response size
+* e: query response time
 
 ### 2. Unauthenticated user activity events
 Log Collection Principle(s): 6
 
 Where unauthenticated users interact with applications (for example, a MOJ G-Suite document available on the general Internet through relaxed access controls), associated audit information must be created.
 
-* a. end-client identifier(s)
-* b. query metadata
+* a: end-client identifier(s)
+* b: query metadata
     * 1: destination identifier (such as target hostname, TCP/UDP port and/or full URI)
     * 2: query type (for example, HTTP GET or HTTP POST)
     * 3: query size
-* c. response size
-* d. response time
+* c: response size
+* d: response time

--- a/standards/custom-applications.md
+++ b/standards/custom-applications.md
@@ -27,16 +27,16 @@ User directories within application environments can be rich and diverse, such t
 * Local user stores within operating systems leveraged by tenant applications
 
 These event types must be logged and forward:
-* a. account creation
-* b. account lockout
-* c. account reinstatement
-* d. account authentication failures
-* e. account authentication successes after 1 or more failures
-* f. account password changes
-* g. group membership addition / deletion (in particular, any group that gives admin access)
-* h. group creation
-* i. privilege modification for users (for example, role delegation through AWS IAM)
-* k. multi-factor authentication state, such as:
+* a: account creation
+* b: account lockout
+* c: account reinstatement
+* d: account authentication failures
+* e: account authentication successes after 1 or more failures
+* f: account password changes
+* g: group membership addition / deletion (in particular, any group that gives admin access)
+* h: group creation
+* i: privilege modification for users (for example, role delegation through AWS IAM)
+* k: multi-factor authentication state, such as:
     * 1: enabled
     * 2: disabled
     * 3: reset/rotation
@@ -47,23 +47,23 @@ Log Collection Principle(s): 6
 
 Applications should create viable user activity audit information for authenticated users so it is reasonably possible to understand retrospectively which actions the user took or attempted.
 
-* a. user/group identifier(s)
-* b. action/query
-* c. response size
-* d. response time
+* a: user/group identifier(s)
+* b: action/query
+* c: response size
+* d: response time
 
 ### 3. Unauthenticated user activity events
 Log Collection Principle(s): 6
 
 Where unauthenticated users interact with applications (for example, a digital service published and available on the general Internet), associated audit information must be created.
 
-* a. end-client identifier(s) 
-* b. query metadata
+* a: end-client identifier(s) 
+* b: query metadata
     * 1: destination identifier (such as target hostname, TCP/UDP port and/or full URI)
     * 2: query type (for example, HTTP GET or HTTP POST)
     * 3: query size
-* c. response size
-* d. response time
+* c: response size
+* d: response time
 
 ## Enhanced Maturity Tier
 
@@ -72,10 +72,10 @@ Log Collection Principle(s): 1, 2, 3, 6
 
 Continuous integration and continuous deployment pipelines obey instructions to manage applications and are a privileged position to oversee all associated resources, they must be highly auditable to clarify activity and attribute the same.
 
-* a. source identifier(s)
+* a: source identifier(s)
     * 1: user(s)
     * 2: repository
-* b. activity events
+* b: activity events
     * 1: resource creation
     * 2: resource destruction
     * 3: target environment
@@ -85,8 +85,8 @@ Log Collection Principle(s): 6
 
 Temporary data stores (such as intermediate queues) and permanent data store (such as databases) are key data locations and all interactions should be highly auditable.
 
-* a. data store identifier(s)
-* b. credential identifier(s)
-* c. query
-* d. query response size
-* e. query response time
+* a: data store identifier(s)
+* b: credential identifier(s)
+* c: query
+* d: query response size
+* e: query response time

--- a/standards/custom-applications.md
+++ b/standards/custom-applications.md
@@ -37,10 +37,10 @@ These event types must be logged and forward:
 * h. group creation
 * i. privilege modification for users (for example, role delegation through AWS IAM)
 * k. multi-factor authentication state, such as:
-⋅⋅1. enabled
-⋅⋅2. disabled
-⋅⋅3. reset/rotation
-⋅⋅4. recovery method used
+    * 1: enabled
+    * 2: disabled
+    * 3: reset/rotation
+    * 4: recovery method used
 
 ### 2. Authenticated user activity events
 Log Collection Principle(s): 6
@@ -59,9 +59,9 @@ Where unauthenticated users interact with applications (for example, a digital s
 
 * a. end-client identifier(s) 
 * b. query metadata
-⋅⋅1. destination identifier (such as target hostname, TCP/UDP port and/or full URI)
-⋅⋅2. query type (for example, HTTP GET or HTTP POST)
-⋅⋅3. query size
+    * 1: destination identifier (such as target hostname, TCP/UDP port and/or full URI)
+    * 2: query type (for example, HTTP GET or HTTP POST)
+    * 3: query size
 * c. response size
 * d. response time
 
@@ -73,12 +73,12 @@ Log Collection Principle(s): 1, 2, 3, 6
 Continuous integration and continuous deployment pipelines obey instructions to manage applications and are a privileged position to oversee all associated resources, they must be highly auditable to clarify activity and attribute the same.
 
 * a. source identifier(s)
-⋅⋅1. user(s)
-⋅⋅2. repository
+    * 1: user(s)
+    * 2: repository
 * b. activity events
-⋅⋅1. resource creation
-⋅⋅2. resource destruction
-⋅⋅3. target environment
+    * 1: resource creation
+    * 2: resource destruction
+    * 3: target environment
 
 ### 2. Data store events
 Log Collection Principle(s): 6

--- a/standards/enterprise-it-infrastructure.md
+++ b/standards/enterprise-it-infrastructure.md
@@ -30,10 +30,10 @@ These event types must be logged and forward:
 * i. privilege modification for users (changes to ACL’s, granting of new roles in RBAC models)
 * j. privilege escalation events (use of sudo, UAC)
 * k. multi-factor authentication state, such as:
-⋅⋅1. enabled
-⋅⋅2. disabled
-⋅⋅3. reset/rotation
-⋅⋅4. recovery method used
+    * 1: enabled
+    * 2: disabled
+    * 3: reset/rotation
+    * 4: recovery method used
 
 ### 2. Productivity Suite security logs
 Log Collection Principle(s): 1, 2, 3, 6
@@ -50,8 +50,8 @@ DNS query logs must be created and forwarded.
 * a. client IP address
 * b. query
 * c. query response content including
-⋅⋅1. returned record(s) or NXDOMAIN
-⋅⋅2. authoritative nameserver
+    * 1: returned record(s) or NXDOMAIN
+    * 2: authoritative nameserver
 * d. query response code
 * e. zone and/or view identifier (if local zone response and/or multiview)
 
@@ -91,14 +91,14 @@ Log Collection Principle(s): 3, 5
 DHCP services must be configured to create and forward the following:
 
 * a. successful client DHCP requests, including:
-⋅⋅1. Requesting client MAC address
-⋅⋅2. DHCP scope identifier
-⋅⋅3. IP address leased
-⋅⋅4. IP address lease duration
+    * 1: Requesting client MAC address
+    * 2: DHCP scope identifier
+    * 3: IP address leased
+    * 4: IP address lease duration
 
 * b. unsuccessful client DHCP requests, including:
-⋅⋅1. Requesting client MAC address
-⋅⋅2. DHCP scope identifier (if applicable for unsuccessful request)
+    * 1: Requesting client MAC address
+    * 2: DHCP scope identifier (if applicable for unsuccessful request)
 
 ### 8. VPN concentrator activity data
 Log Collection Principle(s): 3, 5
@@ -121,10 +121,10 @@ All firewall ‘DENY’ log data must be forwarded.
 * b. firewall/router identifier
 * c. request response code
 * d. request content, including:
-⋅⋅1. IP protocol (for example, ICMP)
-⋅⋅2. destination/target port
-⋅⋅3. destination/target IP address
-⋅⋅4. destination/target hostname address (if reverse lookup performed)
+    * 1: IP protocol (for example, ICMP)
+    * 2: destination/target port
+    * 3: destination/target IP address
+    * 4: destination/target hostname address (if reverse lookup performed)
 
 ### 2. Internal DNS namespace zone content
 Log Collection Principle(s): 4

--- a/standards/enterprise-it-infrastructure.md
+++ b/standards/enterprise-it-infrastructure.md
@@ -19,17 +19,17 @@ For example:
 * a directory admin logging on to the AD service from their end-user device without logging into the local machine should generate an authentication event for the directory
 
 These event types must be logged and forward:
-* a. account creation
-* b. account lockout
-* c. account reinstatement
-* d. account authentication failures
+* a: account creation
+* b: account lockout
+* c: account reinstatement
+* d: account authentication failures
 * e, account authentication successes after 1 or more failures
-* f. account password changes
-* g. group membership addition / deletion (in particular, any group that gives admin access)
-* h. group creation
-* i. privilege modification for users (changes to ACL’s, granting of new roles in RBAC models)
-* j. privilege escalation events (use of sudo, UAC)
-* k. multi-factor authentication state, such as:
+* f: account password changes
+* g: group membership addition / deletion (in particular, any group that gives admin access)
+* h: group creation
+* i: privilege modification for users (changes to ACL’s, granting of new roles in RBAC models)
+* j: privilege escalation events (use of sudo, UAC)
+* k: multi-factor authentication state, such as:
     * 1: enabled
     * 2: disabled
     * 3: reset/rotation
@@ -47,13 +47,13 @@ Log Collection Principle(s): 4
 
 DNS query logs must be created and forwarded.
 
-* a. client IP address
-* b. query
-* c. query response content including
+* a: client IP address
+* b: query
+* c: query response content including
     * 1: returned record(s) or NXDOMAIN
     * 2: authoritative nameserver
-* d. query response code
-* e. zone and/or view identifier (if local zone response and/or multiview)
+* d: query response code
+* e: zone and/or view identifier (if local zone response and/or multiview)
 
 This remains true for where nodes (for example, servers) may bypass internal DNS services.
 
@@ -62,41 +62,41 @@ Log Collection Principle(s): 5
 
 Where web traffic proxies exist, access logs must be created and forward and must, include the following variables.
 
-* a. authenticated user name
-* b. client IP address
-* c. HTTP method (for example, CONNECT GET)
-* d. full destination/target URL
-* e. connection return status code (for example, 200 or 403)
-* f. size of response
+* a: authenticated user name
+* b: client IP address
+* c: HTTP method (for example, CONNECT GET)
+* d: full destination/target URL
+* e: connection return status code (for example, 200 or 403)
+* f: size of response
 
 ### 5. File server authentication, authorisation and access logs
 Log Collection Principle(s): 6
 
 Where file service exist, sufficient log data must be created and forwarded, including sufficient data to satisfy the following:
 
-* a. detect permission changes and the user who changed such
-* b. detect all file/folder changes and the user who changed such
-* c. detect all file/folder read/open and the user who did such
+* a: detect permission changes and the user who changed such
+* b: detect all file/folder changes and the user who changed such
+* c: detect all file/folder read/open and the user who did such
 
 ### 6. Security-related event logs for all server operating systems
 Log Collection Principle(s): 6
 
 Security-related event logs from all servers (whether virtualised or physical) operating in a ‘server’ role.
 
-* a. [additional information pending]
+* a: [additional information pending]
 
 ### 7. Allocation of IP address leases from DHCP services
 Log Collection Principle(s): 3, 5
 
 DHCP services must be configured to create and forward the following:
 
-* a. successful client DHCP requests, including:
+* a: successful client DHCP requests, including:
     * 1: Requesting client MAC address
     * 2: DHCP scope identifier
     * 3: IP address leased
     * 4: IP address lease duration
 
-* b. unsuccessful client DHCP requests, including:
+* b: unsuccessful client DHCP requests, including:
     * 1: Requesting client MAC address
     * 2: DHCP scope identifier (if applicable for unsuccessful request)
 
@@ -105,10 +105,10 @@ Log Collection Principle(s): 3, 5
 
 Where a end-user device VPN concentrator is in use, connection-related log data must be created and forwarded.
 
-* a. success or unsuccess status
-* b. user/certificate identifier
-* c. client IP address
-* d. concentrator identifier
+* a: success or unsuccess status
+* b: user/certificate identifier
+* c: client IP address
+* d: concentrator identifier
 
 ## Enhanced Maturity Tier
 
@@ -117,10 +117,10 @@ Log Collection Principle(s): 5
 
 All firewall ‘DENY’ log data must be forwarded.
 
-* a. client IP address
-* b. firewall/router identifier
-* c. request response code
-* d. request content, including:
+* a: client IP address
+* b: firewall/router identifier
+* c: request response code
+* d: request content, including:
     * 1: IP protocol (for example, ICMP)
     * 2: destination/target port
     * 3: destination/target IP address
@@ -146,6 +146,6 @@ Log Collection Principle(s): 1, 2, 3, 6
 
 Where a mobile device management solution is used and end-user devices register/enrol and de-register/de-enrol with it, enrollment data should be created in and forwarded.
 
-* a. enrolment or un-enrolment event type
-* b. end-user device identifier(s), such as client IP address and/or MAC address and/or assigned DHCP name
-* c. end-user account name (if applicable)
+* a: enrolment or un-enrolment event type
+* b: end-user device identifier(s), such as client IP address and/or MAC address and/or assigned DHCP name
+* c: end-user account name (if applicable)

--- a/standards/enterprise-it-mobile-devices.md
+++ b/standards/enterprise-it-mobile-devices.md
@@ -14,9 +14,9 @@ Log Collection Principle(s): 1
 
 Devices must create and forward local power events.
 
-* a. power on (including good or bad state)
-* b. power off (including if restart)
-* c. disk encryption state
+* a: power on (including good or bad state)
+* b: power off (including if restart)
+* c: disk encryption state
 
 ### 2. User identification activity
 Log Collection Principle(s): 1, 2
@@ -24,17 +24,17 @@ Log Collection Principle(s): 1, 2
 Devices must create and forward local Authentication and Authorisation events.
 
 These event types must be logged and forward:
-* a. account creation
-* b. account lockout
-* c. account unlock
-* d. account authentication failures
-* e. account authentication successes after 3 or more failures
-* f. account password changes
+* a: account creation
+* b: account lockout
+* c: account unlock
+* d: account authentication failures
+* e: account authentication successes after 3 or more failures
+* f: account password changes
 * g, group membership addition / deletion (in particular, any group that gives admin access)
-* h. group creation
-* i. privilege modification for users (changes to ACL’s, granting of new roles in RBAC models)
-* j. privilege escalation events (use of sudo, UAC)
-* k. multi-factor authentication state, such as:
+* h: group creation
+* i: privilege modification for users (changes to ACL’s, granting of new roles in RBAC models)
+* j: privilege escalation events (use of sudo, UAC)
+* k: multi-factor authentication state, such as:
     * 1: enabled
     * 2: disabled
     * 3: reset/rotation
@@ -45,13 +45,13 @@ Log Collection Principle(s): 4
 
 DNS query logs must be created and forwarded, even where they are captively routed through central enterprise IT DNS services that forward comparable log data.
 
-* a. device IP addresses (local and public, if know/applicable)
-* b. VLAN tag for associated network interface (if known)
-* d. query
-* e. query response content including
+* a: device IP addresses (local and public, if know/applicable)
+* b: VLAN tag for associated network interface (if known)
+* d: query
+* e: query response content including
     * 1: returned record(s) or NXDOMAIN
     * 2: authoritative nameserver
-* e. query response code
+* e: query response code
 
 ### 4. Security-related operating system event data
 Log Collection Principle(s): 6
@@ -65,24 +65,24 @@ Log Collection Principle(s): 6
 
 Security-related logs from any local endpoint protection software (for example, anti-virus) should be forwarded.
 
-* a. detection information
+* a: detection information
     * 1: process/binaries
     * 2: detection criteria (for example, malware type)
-* b. reaction information (for example, quarantine)
-* c. ‘last scan’ information
-* d. signature information
+* b: reaction information (for example, quarantine)
+* c: ‘last scan’ information
+* d: signature information
 
 ### 6. Network information
 Log Collection Principle(s): 5
 
 Devices must create and forward sufficient data to record the network posture around the device.
 
-* a. IP address of DHCP server
-* b. IP address leased
-* c. IP address subnet leased
-* d. IP address lease duration
-* e. Network interface identifier
-* f. DHCP response instructions, for example:
+* a: IP address of DHCP server
+* b: IP address leased
+* c: IP address subnet leased
+* d: IP address lease duration
+* e: Network interface identifier
+* f: DHCP response instructions, for example:
     * 1: DNS servers
     * 2: Proxy servers
 
@@ -91,10 +91,10 @@ Log Collection Principle(s): 5
 
 Where dial-up VPN is in use, connection-related log data must be created and forwarded.
 
-* a. success or unsuccess status
-* b. VPN concentrator domain name and IP address
-* c. user/certificate identifier(s) used
-* d. network interface identifier
+* a: success or unsuccess status
+* b: VPN concentrator domain name and IP address
+* c: user/certificate identifier(s) used
+* d: network interface identifier
 
 ## Enhanced Maturity Tier
 
@@ -103,10 +103,10 @@ Log Collection Principle(s): 5
 
 All firewall ‘DENY’ log data must be forwarded.
 
-* a. client IP address
-* b. network interface identifier(s)
-* c. request response code
-* d. request content, including:
+* a: client IP address
+* b: network interface identifier(s)
+* c: request response code
+* d: request content, including:
     * 1: IP protocol (for example, ICMP)
     * 2: destination/target port
     * 3: destination/target IP address
@@ -117,15 +117,15 @@ Log Collection Principle(s): 6
 
 Log data to reflect the launching and subsequent processing activity stemming from user, or user profile, triggered commands/executables.
 
-* a. user identifier(s)
-* b. device identifier(s)
-* c. command executed
-* d. executable launched
+* a: user identifier(s)
+* b: device identifier(s)
+* c: command executed
+* d: executable launched
 
 ### 3. Configuration information
 Log Collection Principle(s): 6
 
 Devices must create and forward sufficient data to record the changing state of device configurations.
 
-* a. profile or GPO changes
-* b. conflict detection
+* a: profile or GPO changes
+* b: conflict detection

--- a/standards/enterprise-it-mobile-devices.md
+++ b/standards/enterprise-it-mobile-devices.md
@@ -35,10 +35,10 @@ These event types must be logged and forward:
 * i. privilege modification for users (changes to ACL’s, granting of new roles in RBAC models)
 * j. privilege escalation events (use of sudo, UAC)
 * k. multi-factor authentication state, such as:
-⋅⋅1. enabled
-⋅⋅2. disabled
-⋅⋅3. reset/rotation
-⋅⋅4. recovery method used
+    * 1: enabled
+    * 2: disabled
+    * 3: reset/rotation
+    * 4: recovery method used
 
 ### 3. Domain name service query logs
 Log Collection Principle(s): 4
@@ -49,8 +49,8 @@ DNS query logs must be created and forwarded, even where they are captively rout
 * b. VLAN tag for associated network interface (if known)
 * d. query
 * e. query response content including
-⋅⋅1. returned record(s) or NXDOMAIN
-⋅⋅2. authoritative nameserver
+    * 1: returned record(s) or NXDOMAIN
+    * 2: authoritative nameserver
 * e. query response code
 
 ### 4. Security-related operating system event data
@@ -66,8 +66,8 @@ Log Collection Principle(s): 6
 Security-related logs from any local endpoint protection software (for example, anti-virus) should be forwarded.
 
 * a. detection information
-⋅⋅1. process/binaries
-⋅⋅2. detection criteria (for example, malware type)
+    * 1: process/binaries
+    * 2: detection criteria (for example, malware type)
 * b. reaction information (for example, quarantine)
 * c. ‘last scan’ information
 * d. signature information
@@ -83,8 +83,8 @@ Devices must create and forward sufficient data to record the network posture ar
 * d. IP address lease duration
 * e. Network interface identifier
 * f. DHCP response instructions, for example:
-⋅⋅1. DNS servers
-⋅⋅2. Proxy servers
+    * 1: DNS servers
+    * 2: Proxy servers
 
 ### 7. VPN dial-up activity
 Log Collection Principle(s): 5
@@ -107,10 +107,10 @@ All firewall ‘DENY’ log data must be forwarded.
 * b. network interface identifier(s)
 * c. request response code
 * d. request content, including:
-⋅⋅1. IP protocol (for example, ICMP)
-⋅⋅2. destination/target port
-⋅⋅3. destination/target IP address
-⋅⋅4. destination/target hostname address (if reverse lookup performed)
+    * 1: IP protocol (for example, ICMP)
+    * 2: destination/target port
+    * 3: destination/target IP address
+    * 4: destination/target hostname address (if reverse lookup performed)
 
 ### 2. Command/executable runtime information
 Log Collection Principle(s): 6

--- a/standards/hosting-platforms.md
+++ b/standards/hosting-platforms.md
@@ -26,16 +26,16 @@ User directories within hosting environments can be rich and diverse, such techn
 * Local user stores within operating systems
 
 These event types must be logged and forward:
-* a. account creation
-* b. account lockout
-* c. account reinstatement
-* d. account authentication failures
-* e. account authentication successes after 1 or more failures
-* f. account password changes
-* g. group membership addition / deletion (in particular, any group that gives admin access)
-* h. group creation
-* i. privilege modification for users (for example, role delegation through AWS IAM)
-* k. multi-factor authentication state, such as:
+* a: account creation
+* b: account lockout
+* c: account reinstatement
+* d: account authentication failures
+* e: account authentication successes after 1 or more failures
+* f: account password changes
+* g: group membership addition / deletion (in particular, any group that gives admin access)
+* h: group creation
+* i: privilege modification for users (for example, role delegation through AWS IAM)
+* k: multi-factor authentication state, such as:
     * 1: enabled
     * 2: disabled
     * 3: reset/rotation
@@ -46,10 +46,10 @@ Log Collection Principle(s): 1, 2, 6
 
 Bastion/jump boxes that act as a management consolidation route and should be highly auditable therefore must create and forward security-related event data.
 
-* a. SSH keypair generation/revocation, including:
+* a: SSH keypair generation/revocation, including:
     * 1: public key
     * 2: keypair ‘friendly name’ / identifier
-* b. account login attempts
+* b: account login attempts
     * 1: public key
     * 2: username
 
@@ -58,13 +58,13 @@ Log Collection Principle(s): 4
 
 DNS query logs must be created and forwarded.
 
-* a. client IP address
-* b. query
-* c. query response content including
+* a: client IP address
+* b: query
+* c: query response content including
     * 1: returned record(s) or NXDOMAIN
     * 2: authoritative nameserver
-* d. query response code
-* e. zone and/or view identifier (if local zone response and/or multiview)
+* d: query response code
+* e: zone and/or view identifier (if local zone response and/or multiview)
 
 This remains true for where nodes (for example, servers) may bypass internal DNS services.
 
@@ -73,30 +73,30 @@ Log Collection Principle(s): 5
 
 Where web traffic proxies exist, access logs should be created and forward and must, include the following variables.
 
-* a. authenticated user name (if applicable)
-* b. client identifiers:
+* a: authenticated user name (if applicable)
+* b: client identifiers:
     * 1: IP address
     * 2: reverse lookup client name (if applicable)
-* c. HTTP method (for example, CONNECT GET)
-* d. Where available, full destination/target URL or SNI value
-* e. connection return status code (for example, 200 or 403)
-* f. size of response
+* c: HTTP method (for example, CONNECT GET)
+* d: Where available, full destination/target URL or SNI value
+* e: connection return status code (for example, 200 or 403)
+* f: size of response
 
 ### 5. Hypervisor events
 Log Collection Principle(s): 3, 6
 
 Hypervisors manage virtualised compute resources and are entrusted to segregate the same. All instructions to hypervisors should be highly auditable.
 
-* a. virtual machine creation (including templates)
+* a: virtual machine creation (including templates)
     * 1: identifier(s)
     * 2: operating system image information
-* b. virtual machine ‘power’ events
+* b: virtual machine ‘power’ events
     * 1: identifier(s)
     * 2: ‘power’ on
     * 3: ‘power’ off (including restart flag)
-* c. virtual machine deletion
+* c: virtual machine deletion
     * 1: identifier(s)
-* d. virtual machine resource modification events:
+* d: virtual machine resource modification events:
     * 1: CPU addition/removal
     * 2: RAM addition/removal
     * 3: Networking additional/removal
@@ -107,17 +107,17 @@ Log Collection Principle(s): 3, 6
 
 Orchestrators such as Cloud Foundry and Kubernetes create and manage a variety of technology resources to facilitate an application environment.
 
-* a. resource creation (including templates)
+* a: resource creation (including templates)
     * 1: identifier(s)
     * 2: resource type
     * 3: operating system image information (if applicable)
-* b. container ‘power’ events
+* b: container ‘power’ events
     * 1: identifier(s)
     * 2: ‘power’ on
     * 3: ‘power’ off (including restart flag)
-* c. resource deletion
+* c: resource deletion
     * 1: identifier(s)
-* e. resource modification events:
+* e: resource modification events:
     * 1: identifier(s)
 
 ### 7. Allocation of IP address leases from DHCP services
@@ -125,13 +125,13 @@ Log Collection Principle(s): 3, 5
 
 DHCP services must be configured to create and forward the following:
 
-* a. successful client DHCP requests, including:
+* a: successful client DHCP requests, including:
     * 1: Requesting client MAC address
     * 2: DHCP scope identifier
     * 3: IP address leased
     * 4: IP address lease duration
 
-* b. unsuccessful client DHCP requests, including:
+* b: unsuccessful client DHCP requests, including:
     * 1: Requesting client MAC address
     * 2: DHCP scope identifier (if applicable for unsuccessful request)
 
@@ -142,10 +142,10 @@ Log Collection Principle(s): 5
 
 All firewall ‘DENY’ log data must be forwarded.
 
-* a. client IP address
-* b. firewall/router identifier
-* c. request response code
-* d. request content, including:
+* a: client IP address
+* b: firewall/router identifier
+* c: request response code
+* d: request content, including:
     * 1: IP protocol (for example, ICMP)
     * 2: destination/target port
     * 3: destination/target IP address
@@ -176,28 +176,28 @@ Log Collection Principle(s): 1, 2, 3, 6
 
 Where a mobile device management solution is used and end-user devices register/enrol and de-register/de-enrol with it, enrollment data should be created in and forwarded.
 
-* a. enrolment or un-enrolment event type
-* b. end-user device identifier(s), such as client IP address and/or MAC address and/or assigned DHCP name
-* c. end-user account name (if applicable)
+* a: enrolment or un-enrolment event type
+* b: end-user device identifier(s), such as client IP address and/or MAC address and/or assigned DHCP name
+* c: end-user account name (if applicable)
 
 ### 7. VPN concentrator activity data
 Log Collection Principle(s): 3, 5
 
 Where VPN services are in use, connection-related log data must be created and forwarded.
 
-* a. success or unsuccess status
-* b. user/certificate identifier
-* c. client IP address
-* d. concentrator identifier
+* a: success or unsuccess status
+* b: user/certificate identifier
+* c: client IP address
+* d: concentrator identifier
 
 ### 8. Pipeline events
 Log Collection Principle(s): 1, 2, 3, 6
 
 Continuous integration and continuous deployment pipelines obey instructions to manage hosting environments and are a privileged position to oversee all tenant resources, they must be highly auditable to clarify activity and attribute the same.
 
-* a. source identifier(s)
+* a: source identifier(s)
     * 1: user(s)
     * 2: repository
-* b. activity events
+* b: activity events
     * 1: resource creation
     * 2: resource destruction

--- a/standards/hosting-platforms.md
+++ b/standards/hosting-platforms.md
@@ -36,10 +36,10 @@ These event types must be logged and forward:
 * h. group creation
 * i. privilege modification for users (for example, role delegation through AWS IAM)
 * k. multi-factor authentication state, such as:
-⋅⋅1. enabled
-⋅⋅2. disabled
-⋅⋅3. reset/rotation
-⋅⋅4. recovery method used
+    * 1: enabled
+    * 2: disabled
+    * 3: reset/rotation
+    * 4: recovery method used
 
 ### 2. Bastion/Jump/Action-proxy services
 Log Collection Principle(s): 1, 2, 6
@@ -47,11 +47,11 @@ Log Collection Principle(s): 1, 2, 6
 Bastion/jump boxes that act as a management consolidation route and should be highly auditable therefore must create and forward security-related event data.
 
 * a. SSH keypair generation/revocation, including:
-⋅⋅1. public key
-⋅⋅2. keypair ‘friendly name’ / identifier
+    * 1: public key
+    * 2: keypair ‘friendly name’ / identifier
 * b. account login attempts
-⋅⋅1. public key
-⋅⋅2. username
+    * 1: public key
+    * 2: username
 
 ### 3. Domain name service query logs
 Log Collection Principle(s): 4
@@ -61,8 +61,8 @@ DNS query logs must be created and forwarded.
 * a. client IP address
 * b. query
 * c. query response content including
-⋅⋅1. returned record(s) or NXDOMAIN
-⋅⋅2. authoritative nameserver
+    * 1: returned record(s) or NXDOMAIN
+    * 2: authoritative nameserver
 * d. query response code
 * e. zone and/or view identifier (if local zone response and/or multiview)
 
@@ -75,8 +75,8 @@ Where web traffic proxies exist, access logs should be created and forward and m
 
 * a. authenticated user name (if applicable)
 * b. client identifiers:
-⋅⋅1. IP address
-⋅⋅2. reverse lookup client name (if applicable)
+    * 1: IP address
+    * 2: reverse lookup client name (if applicable)
 * c. HTTP method (for example, CONNECT GET)
 * d. Where available, full destination/target URL or SNI value
 * e. connection return status code (for example, 200 or 403)
@@ -88,19 +88,19 @@ Log Collection Principle(s): 3, 6
 Hypervisors manage virtualised compute resources and are entrusted to segregate the same. All instructions to hypervisors should be highly auditable.
 
 * a. virtual machine creation (including templates)
-⋅⋅1. identifier(s)
-⋅⋅2. operating system image information
+    * 1: identifier(s)
+    * 2: operating system image information
 * b. virtual machine ‘power’ events
-⋅⋅1. identifier(s)
-⋅⋅2. ‘power’ on
-⋅⋅3. ‘power’ off (including restart flag)
+    * 1: identifier(s)
+    * 2: ‘power’ on
+    * 3: ‘power’ off (including restart flag)
 * c. virtual machine deletion
-⋅⋅1. identifier(s)
+    * 1: identifier(s)
 * d. virtual machine resource modification events:
-⋅⋅1. CPU addition/removal
-⋅⋅2. RAM addition/removal
-⋅⋅3. Networking additional/removal
-⋅⋅4. Storage mount/dismount/resize
+    * 1: CPU addition/removal
+    * 2: RAM addition/removal
+    * 3: Networking additional/removal
+    * 4: Storage mount/dismount/resize
 
 ### 6. Orchestrator events
 Log Collection Principle(s): 3, 6
@@ -108,17 +108,17 @@ Log Collection Principle(s): 3, 6
 Orchestrators such as Cloud Foundry and Kubernetes create and manage a variety of technology resources to facilitate an application environment.
 
 * a. resource creation (including templates)
-⋅⋅1. identifier(s)
-⋅⋅2. resource type
-⋅⋅3. operating system image information (if applicable)
+    * 1: identifier(s)
+    * 2: resource type
+    * 3: operating system image information (if applicable)
 * b. container ‘power’ events
-⋅⋅1. identifier(s)
-⋅⋅2. ‘power’ on
-⋅⋅3. ‘power’ off (including restart flag)
+    * 1: identifier(s)
+    * 2: ‘power’ on
+    * 3: ‘power’ off (including restart flag)
 * c. resource deletion
-⋅⋅1. identifier(s)
+    * 1: identifier(s)
 * e. resource modification events:
-⋅⋅1. identifier(s)
+    * 1: identifier(s)
 
 ### 7. Allocation of IP address leases from DHCP services
 Log Collection Principle(s): 3, 5
@@ -126,14 +126,14 @@ Log Collection Principle(s): 3, 5
 DHCP services must be configured to create and forward the following:
 
 * a. successful client DHCP requests, including:
-⋅⋅1. Requesting client MAC address
-⋅⋅2. DHCP scope identifier
-⋅⋅3. IP address leased
-⋅⋅4. IP address lease duration
+    * 1: Requesting client MAC address
+    * 2: DHCP scope identifier
+    * 3: IP address leased
+    * 4: IP address lease duration
 
 * b. unsuccessful client DHCP requests, including:
-⋅⋅1. Requesting client MAC address
-⋅⋅2. DHCP scope identifier (if applicable for unsuccessful request)
+    * 1: Requesting client MAC address
+    * 2: DHCP scope identifier (if applicable for unsuccessful request)
 
 ## Enhanced Maturity Tier
 
@@ -146,10 +146,10 @@ All firewall ‘DENY’ log data must be forwarded.
 * b. firewall/router identifier
 * c. request response code
 * d. request content, including:
-⋅⋅1. IP protocol (for example, ICMP)
-⋅⋅2. destination/target port
-⋅⋅3. destination/target IP address
-⋅⋅4. destination/target hostname address (if reverse lookup performed)
+    * 1: IP protocol (for example, ICMP)
+    * 2: destination/target port
+    * 3: destination/target IP address
+    * 4: destination/target hostname address (if reverse lookup performed)
 
 ### 2. Internal DNS namespace zone content
 Log Collection Principle(s): 4
@@ -196,8 +196,8 @@ Log Collection Principle(s): 1, 2, 3, 6
 Continuous integration and continuous deployment pipelines obey instructions to manage hosting environments and are a privileged position to oversee all tenant resources, they must be highly auditable to clarify activity and attribute the same.
 
 * a. source identifier(s)
-⋅⋅1. user(s)
-⋅⋅2. repository
+    * 1: user(s)
+    * 2: repository
 * b. activity events
-⋅⋅1. resource creation
-⋅⋅2. resource destruction
+    * 1: resource creation
+    * 2: resource destruction

--- a/standards/log-entry-metadata.md
+++ b/standards/log-entry-metadata.md
@@ -10,13 +10,13 @@ Any security log data collected must comply with these metadata standards to ens
 ## Time/date
 
 * a. all log events must be time stamped in the common log timestamping format as defined by [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) `[dd/MM/yyyy:hh:mm:ss +-hhmm]` where the fields are defined as follows:
-⋅⋅1. dd is the day of the month
-⋅⋅2. MMM is the month
-⋅⋅3. yyyy is the year
-⋅⋅4. :hh is the hour
-⋅⋅5. :mm is the minute
-⋅⋅6. :ss is the seconds
-⋅⋅7. +-hhmm is the time zone
+    * 1: dd is the day of the month
+    * 2: MMM is the month
+    * 3: yyyy is the year
+    * 4: :hh is the hour
+    * 5: :mm is the minute
+    * 6: :ss is the seconds
+    * 7: +-hhmm is the time zone
 * b. systems must use an automated time syncing protocol (such as NTP) with an external time source to ensure it is not subject to ‘time drift’ that may impact the accuracy of time stamping.
 
 ## Formats

--- a/standards/log-entry-metadata.md
+++ b/standards/log-entry-metadata.md
@@ -9,7 +9,7 @@ Any security log data collected must comply with these metadata standards to ens
 
 ## Time/date
 
-* a. all log events must be time stamped in the common log timestamping format as defined by [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) `[dd/MM/yyyy:hh:mm:ss +-hhmm]` where the fields are defined as follows:
+* a: all log events must be time stamped in the common log timestamping format as defined by [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) `[dd/MM/yyyy:hh:mm:ss +-hhmm]` where the fields are defined as follows:
     * 1: dd is the day of the month
     * 2: MMM is the month
     * 3: yyyy is the year
@@ -17,17 +17,17 @@ Any security log data collected must comply with these metadata standards to ens
     * 5: :mm is the minute
     * 6: :ss is the seconds
     * 7: +-hhmm is the time zone
-* b. systems must use an automated time syncing protocol (such as NTP) with an external time source to ensure it is not subject to ‘time drift’ that may impact the accuracy of time stamping.
+* b: systems must use an automated time syncing protocol (such as NTP) with an external time source to ensure it is not subject to ‘time drift’ that may impact the accuracy of time stamping.
 
 ## Formats
 
 Only the following log file formats should be used:
 
-* a. Apache Common Log Format
-* b. NCSA (Common or Access, Combined, and Separate or 3-Log)
-* c. Windows Event Log
-* d. W3C Extended Log File Format
-* e. W3C Extended (used by Microsoft IIS 4.0 and 5.0)
-* f. SunTM ONE Web Server (iPlanet)
-* g. IBM Tivoli Access Manager WebSEAL
-* h. WebSphere Application Server Logs
+* a: Apache Common Log Format
+* b: NCSA (Common or Access, Combined, and Separate or 3-Log)
+* c: Windows Event Log
+* d: W3C Extended Log File Format
+* e: W3C Extended (used by Microsoft IIS 4.0 and 5.0)
+* f: SunTM ONE Web Server (iPlanet)
+* g: IBM Tivoli Access Manager WebSEAL
+* h: WebSphere Application Server Logs


### PR DESCRIPTION
See the first commit message for context on why I chose this approach.

This change makes the nested lists easier to read when rendered, but the switch to use `:` after the letters/numbers may be too confusing for editors, so I'm happy for people to suggest other approaches or to not merge and leave it as it is.