### PR TITLE
Specify correct directory for previewing with Jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ manager][rvm].
 [bundler]: http://bundler.io/
 
 Once you have Ruby and Bundler set up, you can install this project's
-dependencies by running the following in this directory:
+dependencies by running the following in the `docs` directory:
 
 ```bash
 bundle install


### PR DESCRIPTION
This PR specifies the correct directory in which you need to run `bundle`, to preview the Security Guidance with Jekyll.