### PR TITLE
Update leak-handling-process.md

### DIFF
--- a/docs/leak-handling-process.md
+++ b/docs/leak-handling-process.md
@@ -4,9 +4,9 @@ This document provides a high-level overview of the leak handling process for th
 
 It should be read in conjunction with the associated [leak handling policy](leak-handling-policy.md).
 
-[MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk) owns the leak handling process. However, the [Operational Security Team](mailto:OperationalSecurityTeam@justice.gov.uk) provides tech support as required, for example performing searches. The analysis and reporting from these teams is an essential security management component in assessing and mitigating current and future leaks that affect MoJ data, systems, networks and solutions.
+[MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk) owns the leak handling process. However, the [Operational Security Team](mailto:OperationalSecurityTeam@justice.gov.uk) provides tech support as required, for example, performing searches. The analysis and reporting from these teams is an essential security management component in assessing and mitigating current and future leaks that affect MoJ data, systems, networks and solutions.
 
-Send all leak questions or requests for help to [security@justice.gov.uk](mailto:security@justice.gov.uk). This applies to all leaks, suspected or otherwise. Your message is evaluated promptly, and normally passed to [MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk). Depending on the circumstances, the [Operational Security Team](mailto:OperationalSecurityTeam@justice.gov.uk) might also provide direct advice on a case-by-case basis.
+Send all leak questions or requests for help to [security@justice.gov.uk](mailto:security@justice.gov.uk). This applies to all leaks, suspected or otherwise. Your message is evaluated promptly and normally passed to [MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk). Depending on the circumstances, the [Operational Security Team](mailto:OperationalSecurityTeam@justice.gov.uk) might also provide direct advice on a case-by-case basis.
 
 **Note:** Normally, the [MoJ incident management process](it-incident-management-policy.md) is followed at the start of a leak investigation.
 
@@ -21,7 +21,7 @@ Send all leak questions or requests for help to [security@justice.gov.uk](mailto
 
 ## Audience
 
-This process is aimed at all other staff working for, or supplying services to, the MoJ. This includes General users, Technical users, contractors, third parties, and Service Providers.
+This process is aimed at all staff working for or supplying services to the MoJ. This includes General users, Technical users, contractors, third parties, and Service Providers.
 
 ## Roles and responsibilities
 
@@ -45,20 +45,20 @@ This process is aimed at all other staff working for, or supplying services to, 
 
     1.  Reviews the information available.
     2.  Defines the scope of the informal investigation \(internal to the MoJ\).
-    3.  Provides the Cyber Security Team with the defined investigation scope, and requests an electronic investigation if required.
+    3.  Provides the Cyber Security Team with the defined investigation scope and requests an electronic investigation if required.
     4.  Issues the leak questionnaire to those known to have had access to the leaked information.
     5.  Reviews all evidence gathered, and prepares the informal leak report.
 <a name="ia-lead-case-manager-or-requestor"></a>
 
 -   **IA Lead, Case Manager or Requestor**
 
-    Addresses all investigation requirements. Provides governance sign-off. Communicates with Operational Security team on case status, including case closure notification or retention date.
+    Addresses all investigation requirements. Provides governance sign-off. Communicates with the Operational Security team on case status, including case closure notification or retention date.
 
 <a name="operational-security-front-door-team"></a>
 
 -   **Operational Security 'Front Door' team**
 
-    Triages and formally logs incidents using ServiceNow. Works closely with all other security teams to resolve or escalate as required. The Front Door team ensures that the Chief Security Officer is notified and kept informed of all suspected leak incidents.
+    Triages and formally logs incidents using ServiceNow. Works closely with all other security teams to resolve or escalate as required. The Front Door team ensures that the Chief Security Officer is notified and informed of all suspected leak incidents.
 
 <a name="operational-security-team"></a>
 
@@ -91,9 +91,9 @@ This process is aimed at all other staff working for, or supplying services to, 
 
 1.  The 'front door' security team evaluates the request.
 
-2.  If the situation is indeed a leak, the request is sent to [MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk). Proceed to [Require informal leak investigation](#step-21-require-informal-leak-investigation).
+2.  If the situation is indeed a leak, the request is sent to [MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk). Proceed to step [2.1](#step-21-require-informal-leak-investigation).
 
-3.  If the situation is not a leak, or it is not clear whether the situation is a leak, the request is sent to [Operational Security Team](mailto:OperationalSecurityTeam@justice.gov.uk). Proceed to step 2.2.
+3.  If the situation is not a leak, or it is not clear whether the situation is a leak, the request is sent to the [Operational Security Team](mailto:OperationalSecurityTeam@justice.gov.uk). Proceed to step [2.2](#step-22-information-and-sign-off-check).
 
 
 ### Step 2.1: Require informal leak investigation
@@ -107,7 +107,7 @@ This process is aimed at all other staff working for, or supplying services to, 
 
 ### Step 2.1.1: Produce informal investigation report
 
-1.  With input from the Cyber Security Team, Group Security produces an informal investigation report. The report describes the findings and recommendations.
+1.  Group Security produces an informal investigation report with input from the Cyber Security Team. The report describes the findings and recommendations.
 
 2.  The report is sent to the Requestor.
 
@@ -118,7 +118,7 @@ This process is aimed at all other staff working for, or supplying services to, 
 
 1.  The Requestor receives the informal leak report.
 
-2.  If the report is satisfactory, and no escalation is required or requested, then the process ends. No further action is required.
+2.  If the report is satisfactory and no escalation is required or requested, the process ends. No further action is required.
 
 3.  If the report is not satisfactory, or an escalation is required or requested, proceed to step [2.1.3](#step-213-escalate-leak-request).
 
@@ -127,16 +127,16 @@ This process is aimed at all other staff working for, or supplying services to, 
 
 1.  Group Security re-evaluates the leak request.
 
-2.  If Group Security confirm that the report is satisfactory, and no escalation is required or requested, then the process ends. Process ends. No further action is required.
+2.  If Group Security confirms that the report is satisfactory and no escalation is required or requested, the process ends. No further action is required.
 
-3.  If escalation is required, Group Security confirms this by signing off the request. Proceed to step [2.2](#step-22-information-and-sign-off-check).
+3.  If an escalation is required, Group Security confirms this by signing off the request. Proceed to step [2.2](#step-22-information-and-sign-off-check).
 
 
 ### Step 2.2: Information and sign off check
 
-1.  The OST Lead checks that the leak investigation request is complete with all required information and the required sign-off. This confirms legitimacy of the investigation.
+1.  The OST Lead checks that the leak investigation request is complete with all required information and the required sign-off. This confirms the legitimacy of the investigation.
 
-2.  If the request is incomplete or not signed off, the OST Lead connects back to the Requestor to provide this information. The process returns back to step [2.1.2](#step-212-receive-investigation-report).
+2.  If the request is incomplete or not signed off, the OST Lead connects back to the Requestor to provide this information. The process returns to step [2.1.2](#step-212-receive-investigation-report).
 
 3.  If the request is complete and signed off, go to step [2.2.1](#step-221-create-incident).
 
@@ -145,7 +145,7 @@ This process is aimed at all other staff working for, or supplying services to, 
 
 1.  The OST Lead assigns an OST Analyst to the request.
 
-2.  The OST Analyst creates a ServiceNow 'place holder' incident using the Technology Portal. In all cases, the title of the place holder **SHALL** be "An investigation carried out by OST."
+2.  The OST Analyst creates a ServiceNow 'placeholder' incident using the Technology Portal. In all cases, the title of the placeholder **SHALL** be "An investigation carried out by OST."
 
 3.  Proceed to step [2.2.2](#step-222-collect-evidence).
 
@@ -161,20 +161,20 @@ This process is aimed at all other staff working for, or supplying services to, 
 3.  Proceed to step [2.2.3](#step-223-process-evidence-and-produce-report).
 
 
-**Note:** The OST Analyst **SHALL** record all the steps taken for each request in OneNote. These contemporaneous notes **SHALL** include supporting data, such as photos, screenshots and images. In addition, each entry **SHALL** by supported by the Analyst's comments.
+**Note:** The OST Analyst **SHALL** record all the steps taken for each request in OneNote. These contemporaneous notes **SHALL** include supporting data, such as photos, screenshots and images. In addition, each entry **SHALL** be supported by the Analyst's comments.
 
 ### Step 2.2.3: Process evidence and produce report
 
-1.  The OST Analyst processes or analyses the data as needed, and produces a report.
+1.  The OST Analyst processes or analyses the data as needed and produces a report.
 
 2.  Proceed to step [2.2.4](#step-224-close-servicenow-incident).
 
 
 ### Step 2.2.4: Close ServiceNow incident
 
-1.  The OST Analyst confirms with the Requestor that the leak investigation request can be closed.
+1.  The OST Analyst confirms that the leak investigation request can be closed with the Requestor.
 
-2.  When confirmation is received, the OST Analyst provides the Requestor with a concluding report, outlining the findings and recommendations established during step [2.1.4](#step-212-receive-investigation-report).
+2.  When confirmation is received, the OST Analyst provides the Requestor with a concluding report outlining the findings and recommendations established during step [2.1.2](#step-212-receive-investigation-report).
 
 3.  The OST Analyst updates and closes the ServiceNow Incident.
 
@@ -183,7 +183,7 @@ This process is aimed at all other staff working for, or supplying services to, 
 
 ### Step 2.2.5: Update Tracker and OneNote
 
-1.  The OST Analyst updates the Tracker spreadsheet in Teams, and the OneNote record.
+1.  The OST Analyst updates the Tracker spreadsheet in Teams and the OneNote record.
 
 2.  The process ends.
 
@@ -194,7 +194,7 @@ This process is aimed at all other staff working for, or supplying services to, 
 
 Contact [security@justice.gov.uk](mailto:security@justice.gov.uk).
 
-**Note:** To log a security incidents during UK working hours, it must be reported by you using the process on the [Reporting a Security Incident](https://intranet.justice.gov.uk/guidance/security/report-a-security-incident/) page of the MoJ Intranet.
+**Note:** To log a security incidents during UK working hours, you must be reported it  using the process on the [Reporting a Security Incident](https://intranet.justice.gov.uk/guidance/security/report-a-security-incident/) page of the MoJ Intranet.
 
 ## Contact details
 


### PR DESCRIPTION
Hi Adrian, I've gone through this content and it seems complete and simplified but the ordering of the steps have changed. Briefly, this version and my process/RACi doc align up to step 2.1.1, but deviate going forwards. In my doc the internal investigation(before escalation) and the creation of the ServiceNow ticket are in parallel, whereas in this version it is only after escalation (formal investigation) is confirmed the ServiceNow ticket is created.  I take it, this is intentional?  Have carried out snagging on doc for approval.