### PR TITLE
Update leak-handling-process.md

### DIFF
--- a/docs/leak-handling-process.md
+++ b/docs/leak-handling-process.md
@@ -4,13 +4,13 @@ This document provides a high-level overview of the leak handling process for th
 
 It should be read in conjunction with the associated [leak handling policy](leak-handling-policy.md).
 
-[MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk) owns the leak handling process. However, the Investigations SOC Team provides tech support as required, for example performing searches. The analysis and reporting from these teams is an essential security management component in assessing and mitigating current and future leaks that affect MoJ data, systems, networks and solutions.
+[MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk) owns the leak handling process. However, the Justice Digital SOC (Security Operations Centre) provides tech support as required, for example performing searches. The analysis and reporting from these teams is an essential security management component in assessing and mitigating current and future leaks that affect MoJ data, systems, networks and solutions.
 
-Send all leak questions or requests for help to [security@justice.gov.uk](mailto:security@justice.gov.uk). This applies to all leaks, suspected or otherwise. Your message is evaluated promptly and normally passed to [MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk). Depending on the circumstances, the Investigations SOC Team might also provide direct advice on a case-by-case basis.
+Send all leak questions or requests for help to [security@justice.gov.uk](mailto:security@justice.gov.uk). This applies to all leaks, suspected or otherwise. Your message is evaluated promptly and normally passed to [MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk). Depending on the circumstances, the Justice Digital SOC might also provide direct advice on a case-by-case basis.
 
 **Note:** Normally, the [MoJ incident management process](it-incident-management-policy.md) is followed at the start of a leak investigation.
 
-**Note:** If a leak investigation indicates that physical examination of evidence is required, then Investigations SOC Team involvement will include a Team Lead as a minimum.
+**Note:** If a leak investigation indicates that physical examination of evidence is required, then the Justice Digital SOC involvement will include a Team Lead as a minimum.
 
 **Note:** An informal leak investigation takes place entirely within the MoJ. A formal leak investigation takes place with involvement from outside the MoJ, typically Cabinet Office.
 
@@ -43,7 +43,7 @@ This process is aimed at all staff working for, or supplying services to, the Mo
 
     Following authorisation from the MoJ Permanent Secretary, Group Security:
 
-    1.  Reviews the information available.
+    1.  Reviews the information available and triages requests.
     2.  Defines the scope of the informal investigation \(internal to the MoJ\).
     3.  Provides the Cyber Security Team with the defined investigation scope and requests an electronic investigation if required.
     4.  Issues the leak questionnaire to those known to have had access to the leaked information.
@@ -52,11 +52,11 @@ This process is aimed at all staff working for, or supplying services to, the Mo
 
 -   **IA Lead, Case Manager or Requestor**
 
-    Addresses all investigation requirements. Provides governance sign-off. Communicates with the Investigations SOC Team on case status, including case closure notification or retention date.
+    Addresses all investigation requirements. Provides governance sign-off. Communicates with the Justice Digital SOC on case status, including case closure notification or retention date.
 
 <a name="investigations-soc-team"></a>
 
--   **Investigations SOC Team**
+-   **Justice Digital SOC**
 
     Has ownership of all data acquisition, preservation, analysis and reporting. This includes verification of sign-off. Provides regular feedback case review as needed. Tracks incidents using Service-Now and team internal tracker tools.
 
@@ -64,7 +64,7 @@ This process is aimed at all staff working for, or supplying services to, the Mo
 
 -   **Shared Security Team**
 
-    Triages and formally logs incidents using ServiceNow. Works closely with all other security teams to resolve or escalate as required. The [Shared Security Team](mailto:security@justice.gov.uk) ensures that the Chief Security Officer is notified and informed of all suspected leak incidents.
+    Forwards and formally logs incidents using ServiceNow. Works closely with all other security teams to resolve or escalate as required. The [Shared Security Team](mailto:security@justice.gov.uk) ensures that the Chief Security Officer is notified and informed of all suspected leak incidents.
 
 
 ## Process steps
@@ -84,48 +84,56 @@ This process is aimed at all staff working for, or supplying services to, the Mo
     -   Permanent Secretary.
     -   Senior Civil Servant \(SCS\).
     -   Other cross-government source.
+
 2.  The request indicates that a leak investigation is required. The request is submitted to the [Shared Security Team](mailto:security@justice.gov.uk).
 
-3.  Proceed to [step 2](#step-2-is-it-a-leak).
+3.  Proceed to [step 2](#step-2-forward-leak-request).
 
 
-### Step 2: Is it a leak?
+### Step 2: Forward leak request
 
-1.  The [Shared Security Team](mailto:security@justice.gov.uk) evaluates the request.
+1.  The [Shared Security Team](mailto:security@justice.gov.uk) forward all received requests to [MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk).
 
-2.  If the situation is indeed a leak, the request is sent to [MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk). Proceed to step [2.1](#step-21-require-informal-leak-investigation).
-
-3.  If the situation is not a leak, or it is not clear whether the situation is a leak, the request is sent to the Investigations SOC Team. Proceed to step [2.2](#step-22-information-and-sign-off-check).
+2.  Proceed to [step 3](#step-3-is-it-a-leak?).
 
 
-### Step 2.1: Require informal leak investigation
+### Step 3: Is it a leak?
+
+1.  The [MoJ Group Security](mailto:mojgroupsecurity@justice.gov.uk) evaluates the request.
+
+2.  If it is decided the situation is indeed a leak, then proceed to step [3.1](#step-31-require-informal-leak-investigation).
+
+3.  If it is decide the situation is not a leak, or it is not clear whether the situation is a leak, the request is sent to the Justice Digital SOC. Proceed to step [3.2](#step-32-information-and-sign-off-check).
+
+
+### Step 3.1: Require informal leak investigation
 
 1.  Group Security reviews the request to determine if a leak investigation is required.
 
-2.  If a leak investigation is needed, go to step [2.1.1](#step-211-produce-informal-investigation-report).
+2.  If a leak investigation is needed, go to step [3.1.1](#step-311-produce-informal-investigation-report).
 
 3.  If a leak investigation is not needed, the [Shared Security Team](mailto:security@justice.gov.uk) notifies the Requestor that a leak investigation is not required, based on the rationale provided by Group Security. The leak process ends. No further action is required.
 
 
-### Step 2.1.1: Produce informal investigation report
+### Step 3.1.1: Produce informal investigation report
 
 1.  Group Security produces an informal investigation report with input from the Cyber Security Team. The report describes the findings and recommendations.
 
 2.  The report is sent to the Requestor.
 
-3.  Proceed to step [2.1.2](#step-212-receive-investigation-report).
+3.  Proceed to step [3.1.2](#step-312-receive-investigation-report).
 
 
-### Step 2.1.2: Receive investigation report
+### Step 3.1.2: Receive investigation report
 
 1.  The Requestor receives the informal leak report.
 
 2.  If the report is satisfactory, and no escalation is required or requested, the process ends. No further action is required.
 
-3.  If the report is not satisfactory, or an escalation is required or requested, proceed to step [2.1.3](#step-213-escalate-leak-request).
+3.  If the report is not satisfactory, or an escalation is required or requested, proceed to step [3.1.3](#step-313-escalate-leak-request).
 
 
-### Step 2.1.3: Escalate leak request
+### Step 3.1.3: Escalate leak request
 
 1.  Group Security re-evaluates the leak request, in the light of the informal leak report.
 
@@ -133,61 +141,61 @@ This process is aimed at all staff working for, or supplying services to, the Mo
 
 3.  If an escalation is required or requested, Group Security begins the process of requesting formal leak investigation.
 
-4.  Proceed to step [2.2](#step-22-information-and-sign-off-check) to continue and complete the informal leak investigation.
+4.  Proceed to step [3.2](#step-32-information-and-sign-off-check) to continue and complete the informal leak investigation.
 
 
-### Step 2.2: Information and sign off check
+### Step 3.2: Information and sign off check
 
-1.  The Investigations SOC Team Lead checks that the leak investigation request is complete with all required information and the required sign-off. This confirms the legitimacy of the investigation.
+1.  The Justice Digital SOC Lead checks that the leak investigation request is complete with all required information and the required sign-off. This confirms the legitimacy of the investigation.
 
-2.  If the request is incomplete or not signed off, the Investigations SOC Team Lead connects back to the Requestor to provide this information. The process returns to step [2.1.2](#step-212-receive-investigation-report).
+2.  If the request is incomplete or not signed off, the Justice Digital SOC Lead connects back to the Requestor to provide this information. The process returns to step [3.1.2](#step-312-receive-investigation-report).
 
-3.  If the request is complete and signed off, go to step [2.2.1](#step-221-create-incident).
+3.  If the request is complete and signed off, go to step [3.2.1](#step-321-create-incident).
 
 
-### Step 2.2.1: Create incident
+### Step 3.2.1: Create incident
 
-1.  The Investigations SOC Team Lead assigns an Investigations SOC Team Analyst to the request.
+1.  The Justice Digital SOC Lead assigns a Justice Digital SOC Analyst to the request.
 
-2.  The Investigations SOC Team Analyst creates a ServiceNow 'placeholder' incident using the Technology Portal. In all cases, the title of the placeholder **SHALL** be "An investigation carried out by the SOC."
+2.  The Justice Digital SOC Analyst creates a ServiceNow 'placeholder' incident using the Technology Portal. In all cases, the title of the placeholder **SHALL** be "An investigation carried out by the SOC."
 
-3.  Proceed to step [2.2.2](#step-222-collect-evidence).
+3.  Proceed to step [3.2.2](#step-322-collect-evidence).
 
 
 **Note:** **Do not include any case details within the ServiceNow incident.** Use the ServiceNow incident number, plus any Requester case reference numbers or descriptions, for all correspondence, case notes or tracker updates.
 
-### Step 2.2.2: Collect evidence
+### Step 3.2.2: Collect evidence
 
-1.  The Investigations SOC Team Analyst starts the leak investigation, using tools appropriate to the platform, system, or location from which the data was leaked.
+1.  The Justice Digital SOC Analyst starts the leak investigation, using tools appropriate to the platform, system, or location from which the data was leaked.
 
 2.  Evidence is collected, secured and validated with checksums, following forensic best practices.
 
-3.  Proceed to step [2.2.3](#step-223-process-evidence-and-produce-report).
+3.  Proceed to step [3.2.3](#step-323-process-evidence-and-produce-report).
 
 
-**Note:** The Investigations SOC Team Analyst **SHALL** record all the steps taken for each request in OneNote. These contemporaneous notes **SHALL** include supporting data, such as photos, screenshots and images. In addition, each entry **SHALL** be supported by the Analyst's comments.
+**Note:** The Justice Digital SOC Analyst **SHALL** record all the steps taken for each request in OneNote. These contemporaneous notes **SHALL** include supporting data, such as photos, screenshots and images. In addition, each entry **SHALL** be supported by the Analyst's comments.
 
-### Step 2.2.3: Process evidence and produce report
+### Step 3.2.3: Process evidence and produce report
 
-1.  The Investigations SOC Team Analyst processes or analyses the data as needed and produces a report.
+1.  The Justice Digital SOC Analyst processes or analyses the data as needed and produces a report.
 
-2.  Proceed to step [2.2.4](#step-224-close-servicenow-incident).
-
-
-### Step 2.2.4: Close ServiceNow incident
-
-1.  The Investigations SOC Team Analyst confirms that the leak investigation request can be closed with the Requestor.
-
-2.  When confirmation is received, the Investigations SOC Team Analyst provides the Requestor with a concluding report outlining the findings and recommendations established during step [2.1.2](#step-212-receive-investigation-report).
-
-3.  The Investigations SOC Team Analyst updates and closes the ServiceNow Incident.
-
-4.  Proceed to step [2.2.5](#step-225-update-tracker-and-onenote).
+2.  Proceed to step [3.2.4](#step-324-close-servicenow-incident).
 
 
-### Step 2.2.5: Update Tracker and OneNote
+### Step 3.2.4: Close ServiceNow incident
 
-1.  The Investigations SOC Team Analyst updates the Tracker spreadsheet in Teams and the OneNote record.
+1.  The Justice Digital SOC Analyst confirms that the leak investigation request can be closed with the Requestor.
+
+2.  When confirmation is received, the Justice Digital SOC Analyst provides the Requestor with a concluding report outlining the findings and recommendations established during step [3.1.2](#step-312-receive-investigation-report).
+
+3.  The Justice Digital SOC Analyst updates and closes the ServiceNow Incident.
+
+4.  Proceed to step [3.2.5](#step-325-update-tracker-and-onenote).
+
+
+### Step 3.2.5: Update Tracker and OneNote
+
+1.  The Justice Digital SOC Analyst updates the Tracker spreadsheet in Teams and the OneNote record.
 
 2.  The process ends.
 


### PR DESCRIPTION
1. Updated process to include that Shared Security team only forward all requests to Group Security.
2. Updated process steps reference numbering.
3. Updated roles/responsibilities section to state that again, it is the Share Sec team that only forward all requests and Group Sec that triages those requests.
4. Removed explicit refs to "Investigations SOC" or "Misuse Investigation team" and replaced with "Justice Digital SOC" as this is publicly available content.