### PR TITLE
Removal of cybersecurity and vulnerability email address

### DIFF
--- a/docs/vulnerability-disclosure-policy.md
+++ b/docs/vulnerability-disclosure-policy.md
@@ -8,7 +8,7 @@ Where security researchers have submitted qualifying vulnerability reports and h
 
 ## Feedback
 
-If you wish to provide feedback or suggestions on the [MoJ Security Vulnerability Disclosure Policy](https://mojdigital.blog.gov.uk/vulnerability-disclosure-policy/), contact our security team: [cybersecurity+vulnerabilitydisclosure@digital.justice.gov.uk](mailto:cybersecurity+vulnerabilitydisclosure@digital.justice.gov.uk).
+If you wish to provide feedback or suggestions on the [MoJ Security Vulnerability Disclosure Policy](https://mojdigital.blog.gov.uk/vulnerability-disclosure-policy/), contact our security team: [security@justice.gov.uk](mailto:security@justice.gov.uk.)
 
 The policy will naturally evolve over time; your input is welcome and will be valued to ensure that the policy remains clear, complete, and relevant.
 


### PR DESCRIPTION
John says the page looks fine. Just one question is the Vuln Disclosure mailbox (cybersecurity+vulnerabilitydisclosure@digital.justice.gov.uk) still actively managed? I have changed the email address to security as tried to search it I couldn't find it.