### PR TITLE
To add JML toolkit and details on internal movers

### DIFF
--- a/docs/end-or-change-of-employment.md
+++ b/docs/end-or-change-of-employment.md
@@ -1,5 +1,7 @@
 # End or change of employment
 
+When somebody joins, moves or leaves the Department, there are certain security procedures that must be followed to ensure a safe environment for us all. The procedures are outlined in the [Joiners, Movers, and Leaver's (JML) process]. (https://intranet.justice.gov.uk/documents/2021/03/joiners-movers-leavers-toolkit.pdf)  
+
 Managers must ensure that all employees, contractors and third-party users return all assets within their possession and that all access rights \(including building passes, access to buildings, IT systems, applications and directories\) are removed at the point of termination or change of employment.
 
 If the leaver has security clearance, managers should contact the Cluster 2 Security Unit via [Security team](mailto:security@justice.gov.uk) to advise that the person has resigned and tell them their leaving date or the date on which they will be moving to a different department.
@@ -8,11 +10,15 @@ Leavers should read the HR guidance at [End or change employment](https://intran
 
 Managers must also [complete a leaver's checklist](https://intranet.justice.gov.uk/documents/2015/04/leavers-checklist-for-managers.docx) as a record of actions.
 
+If you or someone you’re managing wants to change employment within MoJ, there is guidance on [internal moves] (https://intranet.justice.gov.uk/guidance/hr/end-change-of-employment/internal-moves/). For example, detached duty, managed moves and secondment or loan.  
+
 ## Downloads
 
 [Leavers checklist](https://intranet.justice.gov.uk/documents/2015/04/leavers-checklist-for-managers.docx)
 
-A downloadable version of the "End or change of employment" document is available [here](./gs/end-or-change-of-employment.docx).
+[End or change of employment" document](./gs/end-or-change-of-employment.docx).
+
+[JML Toolkit] (https://intranet.justice.gov.uk/documents/2021/03/joiners-movers-leavers-toolkit.pdf)
 
 ## Contact details
 


### PR DESCRIPTION
John raised the point that nothing is mentioned about internal movers so I approached Maureen for get help. The suggested updates are to include the JML toolkit and a bit more detail on internal movers with a link to an HR internal mover intranet page.