### PR TITLE
Broken link online identifiers

### DIFF
--- a/dita/online-identifiers.dita
+++ b/dita/online-identifiers.dita
@@ -43,7 +43,7 @@
         For example,
         by making a lawful request to an ISP to uncover the person associated with a dynamic IP address at a particular time.</p>
       <p>For more information on this,
-        refer to the Information Commissioner's Office (ICO) <xref href="https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/key-definitions/" format="html" scope="external">key definitions</xref>,
+        refer to the Information Commissioner's Office (ICO) <xref href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/" format="html" scope="external">key definitions</xref>,
         and "<xref href="https://www.privacy-regulation.eu/en/recital-30-GDPR.htm" format="htm" scope="external">Recital 30</xref>"
         from the <xref href="https://en.wikipedia.org/wiki/Article_29_Data_Protection_Working_Party" format="html" scope="external">Article 29 Working Group</xref>.
         There is also an informative article <xref href="https://www.fieldfisher.com/en/services/privacy-security-and-information/privacy-security-and-information-law-blog/can-a-dynamic-ip-address-constitute-personal-data" format="html" scope="external">here</xref>.</p>

--- a/docs/online-identifiers.md
+++ b/docs/online-identifiers.md
@@ -33,7 +33,7 @@ It could be because the user later provides personal data to the MoJ as part of 
 
 There might also be a legal route available to the MoJ to determine the identity behind an identifier. For example, by making a lawful request to an ISP to uncover the person associated with a dynamic IP address at a particular time.
 
-For more information on this, refer to the Information Commissioner's Office \(ICO\) [key definitions](https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/key-definitions/), and "[Recital 30](https://www.privacy-regulation.eu/en/recital-30-GDPR.htm)" from the [Article 29 Working Group](https://en.wikipedia.org/wiki/Article_29_Data_Protection_Working_Party). There is also an informative article [here](https://www.fieldfisher.com/en/services/privacy-security-and-information/privacy-security-and-information-law-blog/can-a-dynamic-ip-address-constitute-personal-data).
+For more information on this, refer to the Information Commissioner's Office \(ICO\) [key definitions](https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/), and "[Recital 30](https://www.privacy-regulation.eu/en/recital-30-GDPR.htm)" from the [Article 29 Working Group](https://en.wikipedia.org/wiki/Article_29_Data_Protection_Working_Party). There is also an informative article [here](https://www.fieldfisher.com/en/services/privacy-security-and-information/privacy-security-and-information-law-blog/can-a-dynamic-ip-address-constitute-personal-data).
 
 ## What does this mean for MoJ services?
 


### PR DESCRIPTION
It has been brought to the team's attention that the online identifiers in security logging and monitoring has a broken link. The broken link is for the more information from the ICO. In this PR request the link has been updated. 

Could you please review the PR request @L-Crosby please?